### PR TITLE
Prevent tasks who fail to be loaded to crash the taskq process endlessly

### DIFF
--- a/taskq/exceptions.py
+++ b/taskq/exceptions.py
@@ -38,3 +38,7 @@ class Retry(TaskControlException):
 
 class Cancel(TaskControlException):
     pass
+
+
+class TaskFatalError(Exception):
+    pass


### PR DESCRIPTION
The tasks are marked as failed when importing the function fails or if the function is not marked with @taskify