### PR TITLE
Handle SyntaxError in scheduled tasks

### DIFF
--- a/taskq/consumer.py
+++ b/taskq/consumer.py
@@ -110,11 +110,11 @@ class Consumer(threading.Thread):
 
         try:
             function = import_function(task.function_name)
-        except ImportError as e:
+        except (ImportError, SyntaxError) as e:
             logger.error(str(e))
             task.status = TaskModel.STATUS_FAILED
             task.save()
-            raise TaskFatalError('Unable to find task function "%s"' % task.function_name)
+            raise TaskFatalError('Unable to import task function "%s"' % task.function_name)
 
         if not isinstance(function, Taskify):
             task.status = TaskModel.STATUS_FAILED


### PR DESCRIPTION
Ca vous semble suffisant pour gérer le problème vu cette nuit?
On pourrait aussi ne pas specifier le type d'exception: c'était mon premier reflexe, mais c'est pas super bonne pratique. Sauf qu'en vrai dans ce cas peut importe l'exception durant `import_function`, on veut marquer la task comme `Failed`.