### PR TITLE
Fix scheduled tasks name

### DIFF
--- a/taskq/consumer.py
+++ b/taskq/consumer.py
@@ -70,7 +70,7 @@ class Consumer:
         with LockedTransaction(Task, "SHARE ROW EXCLUSIVE"):
             for scheduled_task in self._scheduler.due_tasks:
                 task_exists = Task.objects.filter(
-                    function_name=scheduled_task.function_name,
+                    name=scheduled_task.name,
                     due_at=scheduled_task.due_at
                 ).exists()
 


### PR DESCRIPTION
Ne pas se baser sur le nom de la fonction, mais sur le nom du cron.

Ex:
```
'schedule': {
    'my-scheduled-task-1': {
        'task': 'tests.fixtures.task_add',
        'args': {'a': 1, 'b': 1},
        'cron': '0 1 * * *',  # crontab(minute=0, hour=1)
    }
    'my-scheduled-task-2': {
        'task': 'tests.fixtures.task_add',
        'args': {'a': 10, 'b': 42},
        'cron': '0 1 * * *',  # crontab(minute=0, hour=1)
    }
}
```